### PR TITLE
Add debug dependencies

### DIFF
--- a/demo/nvda.gdextension
+++ b/demo/nvda.gdextension
@@ -12,5 +12,7 @@ windows.release.x86_64 = "res://addons/nvda_integration/bin/libgdnvda.windows.te
 
 [dependencies]
 
+windows.debug.x86_32 = { "res://addons/nvda_integration/bin/nvdaControllerClient32.dll": "" }
 windows.release.x86_32 = { "res://addons/nvda_integration/bin/nvdaControllerClient32.dll": "" }
+windows.debug.x86_64 = { "res://addons/nvda_integration/bin/nvdaControllerClient64.dll": "" }
 windows.release.x86_64 = { "res://addons/nvda_integration/bin/nvdaControllerClient64.dll": "" }


### PR DESCRIPTION
Looks like you need to add this if you "export with debug" otherwise it won't include the nvda controller